### PR TITLE
Change default strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ How to correctly use compilation flags see at [sample-app build.gradle file](htt
 Moxy is completely without reflection! No special ProGuard rules required.
 
 ## Road Map
-* [✓] ~~Provide migration mechanic from com.arello-mobile.moxy and its default strategy~~
+* [✓] ~~Provide a migration tool from com.arello-mobile.moxy and its default strategy~~
 * [ ]Kotlin incremental compilation support
 * [ ]Remove reflectors and common presenter store
 * [ ]Provide Runtime Implementation

--- a/README.md
+++ b/README.md
@@ -114,15 +114,42 @@ If you use google material, use `MvpBottomSheetDialogFragment` add this:
 ```groovy
 implementation 'com.github.moxy-community:moxy-material:moxyVersion'
 ```
+## New Features and Compiler option for Migration from old version
+
+By default, each `MvpView` method must has an annotation `@StateStrategy`.
+In the old version of Moxy, it was allowed to miss strategy for methods. In this case, the default strategy was applied.
+
+You can fallback to the old behavior. To do this, set the disableEmptyStrategyCheck parameter to true.
+```kotlin
+disableEmptyStrategyCheck : ‘true’
+```
+
+In this case, the default strategy will be `AddToEndSingleStrategy`. In old version default strategy was` AddToEndStrategy`.
+
+To change default strategy, provide for `defaultMoxyStrategy` parameter the full class name of new default strategy.
+
+```kotlin
+defaultMoxyStrategy : 'moxy.viewstate.strategy.OneExecutionStateStrategy'
+```
+
+If compiler finds `MvpView` method without annotation @StateStrategy it show this error with standard method for notifying about compilation problems.For ease of migration from older versions, we have provided an additional mechanism: `EmptyStrategyHelper`.
+It collects all the errors associated with an empty strategy in one place. Using it, you can easily navigate from the `EmptyStrategyHelper` directly to the method with a missing strategy.
+
+To switch the error output method, enable the option
+```kotlin
+enableEmptyStrategyHelper : 'true'
+```
+
+How to correctly use compilation flags see at [sample-app build.gradle file](https://github.com/moxy-community/Moxy/blob/develop/sample-app/build.gradle)
 
 ## ProGuard
 Moxy is completely without reflection! No special ProGuard rules required.
 
 ## Road Map
-* Provide migration mechanic from com.arello-mobile.moxy and its default strategy
-* Kotlin incremental compilation support
-* Remove reflectors and common presenter store
-* Provide Runtime Implementation
+* [✓] ~~Provide migration mechanic from com.arello-mobile.moxy and its default strategy~~
+* [ ]Kotlin incremental compilation support
+* [ ]Remove reflectors and common presenter store
+* [ ]Provide Runtime Implementation
 
 ## Moxy Community
 Brave people how created library

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ implementation 'com.github.moxy-community:moxy-material:moxyVersion'
 ```
 ## New Features and Compiler option for Migration from old version
 
-By default, each `MvpView` method must has an annotation `@StateStrategy`.
+By default, each `MvpView` method must has an annotation `@StateStrategyType`.
 In the old version of Moxy, it was allowed to miss strategy for methods. In this case, the default strategy was applied.
 
 You can fallback to the old behavior. To do this, set the disableEmptyStrategyCheck parameter to true.
@@ -132,7 +132,7 @@ To change default strategy, provide for `defaultMoxyStrategy` parameter the full
 defaultMoxyStrategy : 'moxy.viewstate.strategy.OneExecutionStateStrategy'
 ```
 
-If compiler finds `MvpView` method without annotation @StateStrategy it show this error with standard method for notifying about compilation problems.For ease of migration from older versions, we have provided an additional mechanism: `EmptyStrategyHelper`.
+If compiler finds `MvpView` method without annotation `@StateStrategyType` it show this error with standard method for notifying about compilation problems.For ease of migration from older versions, we have provided an additional mechanism: `EmptyStrategyHelper`.
 It collects all the errors associated with an empty strategy in one place. Using it, you can easily navigate from the `EmptyStrategyHelper` directly to the method with a missing strategy.
 
 To switch the error output method, enable the option

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ implementation 'com.github.moxy-community:moxy-material:moxyVersion'
 ```
 ## New Features and Compiler option for Migration from old version
 
-By default, each `MvpView` method must has an annotation `@StateStrategyType`.
+By default, each `MvpView` method must have an annotation `@StateStrategyType`.
 In the old version of Moxy, it was allowed to miss strategy for methods. In this case, the default strategy was applied.
 
 You can fallback to the old behavior. To do this, set the disableEmptyStrategyCheck parameter to true.

--- a/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
@@ -48,14 +48,11 @@ public class MvpCompiler extends AbstractProcessor {
 
     private static final String OPTION_MOXY_REFLECTOR_PACKAGE = "moxyReflectorPackage";
 
-    private static final String OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY
-            = "failOnMethodsWithoutStrategy";
+    private static final String OPTION_DISABLE_EMPTY_STRATEGY_CHECK = "disableEmptyStrategyCheck";
 
-    private static final String DEFAULT_MOXY_STRATEGY
-            = "defaultMoxyStrategy";
+    private static final String DEFAULT_MOXY_STRATEGY = "defaultMoxyStrategy";
 
-    private static final String FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER
-            = "failOnMethodsWithoutStrategyHelper";
+    private static final String OPTION_ENABLE_EMPTY_STRATEGY_HELPER = "enableEmptyStrategyHelper";
 
     private static Messager sMessager;
 
@@ -91,9 +88,9 @@ public class MvpCompiler extends AbstractProcessor {
     public Set<String> getSupportedOptions() {
         Set<String> options = new HashSet<>();
         options.add(OPTION_MOXY_REFLECTOR_PACKAGE);
-        options.add(OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY);
+        options.add(OPTION_DISABLE_EMPTY_STRATEGY_CHECK);
         options.add(DEFAULT_MOXY_STRATEGY);
-        options.add(FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER);
+        options.add(OPTION_ENABLE_EMPTY_STRATEGY_HELPER);
         return options;
     }
 
@@ -144,15 +141,13 @@ public class MvpCompiler extends AbstractProcessor {
         PresenterBinderClassGenerator presenterBinderClassGenerator
                 = new PresenterBinderClassGenerator();
 
-        boolean failOnMethodsWithoutStrategy = isOptionEnabled(
-                OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY);
+        boolean disableEmptyStrategyCheck = isOptionEnabled(OPTION_DISABLE_EMPTY_STRATEGY_CHECK);
         String defaultStrategy = getDefaultStrategy();
-        boolean failOnMethodsWithoutStrategyHelper = isOptionEnabled(
-                FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER);
+        boolean enableEmptyStrategyHelper = isOptionEnabled(OPTION_ENABLE_EMPTY_STRATEGY_HELPER);
 
         ViewInterfaceProcessor viewInterfaceProcessor = new ViewInterfaceProcessor(
-                failOnMethodsWithoutStrategy,
-                failOnMethodsWithoutStrategyHelper,
+                disableEmptyStrategyCheck,
+                enableEmptyStrategyHelper,
                 getDefaultStrategy());
         ViewStateClassGenerator viewStateClassGenerator = new ViewStateClassGenerator();
 

--- a/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
@@ -196,7 +196,7 @@ public class MvpCompiler extends AbstractProcessor {
             if (element.getKind() != ElementKind.CLASS) {
                 getMessager().printMessage(Diagnostic.Kind.ERROR,
                         element + " must be " + ElementKind.CLASS.name() + ", or not mark it as @"
-                                + RegisterMoxyReflectorPackages.class.getSimpleName());
+                                + RegisterMoxyReflectorPackages.class.getSimpleName(), element);
             }
 
             String[] packages = element.getAnnotation(RegisterMoxyReflectorPackages.class).value();
@@ -229,7 +229,7 @@ public class MvpCompiler extends AbstractProcessor {
             if (element.getKind() != kind) {
                 getMessager().printMessage(Diagnostic.Kind.ERROR,
                         element + " must be " + kind.name() + ", or not mark it as @" + clazz
-                                .getSimpleName());
+                                .getSimpleName(), element);
             }
 
             generateCode(element, kind, processor, classGenerator);

--- a/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/MvpCompiler.java
@@ -48,14 +48,14 @@ public class MvpCompiler extends AbstractProcessor {
 
     private static final String OPTION_MOXY_REFLECTOR_PACKAGE = "moxyReflectorPackage";
 
-    private static final String OPTION_MOXY_MIRATION_TO_ONE_EXECUTION_STRATEGY
-            = "useMigrationToOneExecutionStrategy";
+    private static final String OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY
+            = "failOnMethodsWithoutStrategy";
 
-    private static final String OPTION_MOXY_USE_OLD_DEFAULT_STRATEGY
-            = "useOldDefaultStrategy";
+    private static final String DEFAULT_MOXY_STRATEGY
+            = "defaultMoxyStrategy";
 
-    private static final String OPTION_MOXY_USE_MIGRATION_HELPER
-            = "useMigrationToOneExecutionStrategyHelper";
+    private static final String FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER
+            = "failOnMethodsWithoutStrategyHelper";
 
     private static Messager sMessager;
 
@@ -91,9 +91,9 @@ public class MvpCompiler extends AbstractProcessor {
     public Set<String> getSupportedOptions() {
         Set<String> options = new HashSet<>();
         options.add(OPTION_MOXY_REFLECTOR_PACKAGE);
-        options.add(OPTION_MOXY_MIRATION_TO_ONE_EXECUTION_STRATEGY);
-        options.add(OPTION_MOXY_USE_OLD_DEFAULT_STRATEGY);
-        options.add(OPTION_MOXY_USE_MIGRATION_HELPER);
+        options.add(OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY);
+        options.add(DEFAULT_MOXY_STRATEGY);
+        options.add(FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER);
         return options;
     }
 
@@ -144,15 +144,16 @@ public class MvpCompiler extends AbstractProcessor {
         PresenterBinderClassGenerator presenterBinderClassGenerator
                 = new PresenterBinderClassGenerator();
 
-        boolean migrationToOneExecutionStrategyEnabled = isOptionEnabled(
-                OPTION_MOXY_MIRATION_TO_ONE_EXECUTION_STRATEGY);
-        boolean useOldDefaultStrategy = isOptionEnabled(OPTION_MOXY_USE_OLD_DEFAULT_STRATEGY);
-        boolean migrationHelperEnabled = isOptionEnabled(OPTION_MOXY_USE_MIGRATION_HELPER);
+        boolean failOnMethodsWithoutStrategy = isOptionEnabled(
+                OPTION_FAIL_ON_METHODS_WITHOUT_STRATEGY);
+        String defaultStrategy = getDefaultStrategy();
+        boolean failOnMethodsWithoutStrategyHelper = isOptionEnabled(
+                FAIL_ON_METHODS_WITHOUT_STRATEGY_BY_MIGRATION_HELPER);
 
         ViewInterfaceProcessor viewInterfaceProcessor = new ViewInterfaceProcessor(
-                migrationToOneExecutionStrategyEnabled,
-                useOldDefaultStrategy,
-                migrationHelperEnabled);
+                failOnMethodsWithoutStrategy,
+                failOnMethodsWithoutStrategyHelper,
+                getDefaultStrategy());
         ViewStateClassGenerator viewStateClassGenerator = new ViewStateClassGenerator();
 
         processInjectors(roundEnv, InjectViewState.class, ElementKind.CLASS,
@@ -192,12 +193,16 @@ public class MvpCompiler extends AbstractProcessor {
         return true;
     }
 
+    private String getDefaultStrategy() {
+        return sOptions.get(DEFAULT_MOXY_STRATEGY);
+    }
+
     private boolean isOptionEnabled(final String option) {
         return Boolean.parseBoolean(sOptions.get(option));
     }
 
     private boolean isUseOldDefaultStrategyEnabled() {
-        String option = sOptions.get(OPTION_MOXY_USE_OLD_DEFAULT_STRATEGY);
+        String option = sOptions.get(DEFAULT_MOXY_STRATEGY);
         return Boolean.parseBoolean(option);
     }
 

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/EmptyStrategyHelperGenerator.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/EmptyStrategyHelperGenerator.java
@@ -9,7 +9,7 @@ import java.util.List;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 
-public class MigrationHelperGenerator {
+public class EmptyStrategyHelperGenerator {
 
 
     /**

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationHelperGenerator.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationHelperGenerator.java
@@ -13,7 +13,7 @@ public class MigrationHelperGenerator {
 
 
     /**
-     * @param destinationPackage package to generate MigrationToOneExecutionStrategyHelper
+     * @param destinationPackage package to generate EmptyStrategyHelper
      * @param migrationMethods   non empty list of methods
      */
     public static JavaFile generate(String destinationPackage,
@@ -22,7 +22,7 @@ public class MigrationHelperGenerator {
         Name firstViewSimpleName = migrationMethods.get(0).clazz.getSimpleName();
 
         TypeSpec.Builder classBuilder = TypeSpec
-                .classBuilder("MigrationToOneExecutionStrategyHelper")
+                .classBuilder("EmptyStrategyHelper")
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
         String javaDoc =

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationHelperGenerator.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationHelperGenerator.java
@@ -1,0 +1,55 @@
+package moxy.compiler.viewstate;
+
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+
+import java.util.List;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.Name;
+
+public class MigrationHelperGenerator {
+
+
+    /**
+     * @param destinationPackage package to generate MigrationToOneExecutionStrategyHelper
+     * @param migrationMethods   non empty list of methods
+     */
+    public static JavaFile generate(String destinationPackage,
+            List<MigrationMethod> migrationMethods) {
+
+        Name firstViewSimpleName = migrationMethods.get(0).clazz.getSimpleName();
+
+        TypeSpec.Builder classBuilder = TypeSpec
+                .classBuilder("MigrationToOneExecutionStrategyHelper")
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
+
+        String javaDoc =
+                String.format(
+                        "This is a helper class. See the clickable list of methods witch need in refactoring.\n"
+                                + "Do not pay attention to errors like:\n\n"
+                                + "\'error: %s is abstract; cannot be instantiated\'\n\n"
+                                + "To complete migration just open the method and set the necessary strategy to it",
+                        firstViewSimpleName);
+        classBuilder.addJavadoc(
+                javaDoc);
+
+        MethodSpec.Builder methodSpecBuilder = MethodSpec.methodBuilder("getViewStateProviders")
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC);
+
+        for (int i = 0; i < migrationMethods.size(); i++) {
+            MigrationMethod migrationMethod = migrationMethods.get(i);
+            String statement = String
+                    .format("new %s().%s()", migrationMethod.clazz.getQualifiedName(),
+                            migrationMethod.method.getSimpleName());
+            methodSpecBuilder.addStatement(statement);
+        }
+
+        classBuilder.addMethod(methodSpecBuilder.build());
+
+        return JavaFile.builder(destinationPackage, classBuilder.build())
+                .indent("\t")
+                .build();
+    }
+}

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationMethod.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/MigrationMethod.java
@@ -1,0 +1,17 @@
+package moxy.compiler.viewstate;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+
+class MigrationMethod {
+
+    TypeElement clazz;
+
+    ExecutableElement method;
+
+    MigrationMethod(final TypeElement clazz,
+            final ExecutableElement method) {
+        this.clazz = clazz;
+        this.method = method;
+    }
+}

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
@@ -117,7 +117,7 @@ public class ViewInterfaceProcessor
 
     public JavaFile makeMigrationHelper(final String moxyReflectorPackage) {
         if (enableEmptyStrategyHelper && !migrationMethods.isEmpty()) {
-            return MigrationHelperGenerator.generate(moxyReflectorPackage, migrationMethods);
+            return EmptyStrategyHelperGenerator.generate(moxyReflectorPackage, migrationMethods);
         }
         return null;
     }

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
@@ -166,8 +166,9 @@ public class ViewInterfaceProcessor
                         migrationMethods.add(new MigrationMethod(typeElement, methodElement));
                     } else {
                         String message = String
-                                .format("No default strategy for method! You are trying migrate to default OneExecutionStrategy, "
-                                                + "but has methods without any Strategy!  See %s method \"%s\"",
+                                .format("A View method has no strategy! You are probably trying to migrate from an "
+                                                + "older version of Moxy. But your %s interface has method \\\"%s\\\" "
+                                                + "without any Strategy, and you did not specify a default Strategy.",
                                         typeElement.getQualifiedName(),
                                         methodElement.getSimpleName()
                                 );

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewInterfaceProcessor.java
@@ -123,7 +123,7 @@ public class ViewInterfaceProcessor
                         methodElement.getSimpleName(),
                         methodElement.getReturnType()
                 );
-                MvpCompiler.getMessager().printMessage(Diagnostic.Kind.ERROR, message);
+                MvpCompiler.getMessager().printMessage(Diagnostic.Kind.ERROR, message, methodElement);
             }
 
             AnnotationMirror annotation = Util

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -25,6 +25,15 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                        moxyMigrationToOneExecutionStrategy: 'false',
+                        useOldDefaultStrategy              : 'false'
+                ]
+            }
+        }
     }
     buildTypes {
         release {

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -29,9 +29,9 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                        failOnMethodsWithoutStrategy      : 'false',
-                        failOnMethodsWithoutStrategyHelper: 'false',
-                        defaultMoxyStrategy               : 'moxy.viewstate.strategy.OneExecutionStateStrategy'
+                        disableEmptyStrategyCheck: 'false',
+                        enableEmptyStrategyHelper: 'true',
+                        defaultMoxyStrategy      : 'moxy.viewstate.strategy.OneExecutionStateStrategy'
                 ]
             }
         }

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -29,9 +29,9 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                        useMigrationToOneExecutionStrategy      : 'false',
-                        useOldDefaultStrategy                   : 'false',
-                        useMigrationToOneExecutionStrategyHelper: 'false'
+                        failOnMethodsWithoutStrategy      : 'false',
+                        failOnMethodsWithoutStrategyHelper: 'false',
+                        defaultMoxyStrategy               : 'moxy.viewstate.strategy.OneExecutionStateStrategy'
                 ]
             }
         }

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -29,8 +29,9 @@ android {
         javaCompileOptions {
             annotationProcessorOptions {
                 arguments = [
-                        moxyMigrationToOneExecutionStrategy: 'false',
-                        useOldDefaultStrategy              : 'false'
+                        useMigrationToOneExecutionStrategy      : 'false',
+                        useOldDefaultStrategy                   : 'false',
+                        useMigrationToOneExecutionStrategyHelper: 'false'
                 ]
             }
         }

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
@@ -1,7 +1,10 @@
 package example.com.androidxsample.view
 
 import moxy.MvpView
+import moxy.viewstate.strategy.AddToEndSingleStrategy
+import moxy.viewstate.strategy.StateStrategyType
 
 interface MainView : MvpView {
-	fun printLog(msg: String)
+    @StateStrategyType(AddToEndSingleStrategy::class)
+    fun printLog(msg: String)
 }

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
@@ -5,6 +5,5 @@ import moxy.viewstate.strategy.AddToEndSingleStrategy
 import moxy.viewstate.strategy.StateStrategyType
 
 interface MainView : MvpView {
-    @StateStrategyType(AddToEndSingleStrategy::class)
     fun printLog(msg: String)
 }

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/MainView.kt
@@ -2,8 +2,10 @@ package example.com.androidxsample.view
 
 import moxy.MvpView
 import moxy.viewstate.strategy.AddToEndSingleStrategy
+import moxy.viewstate.strategy.AddToEndStrategy
 import moxy.viewstate.strategy.StateStrategyType
 
 interface MainView : MvpView {
+    @StateStrategyType(AddToEndStrategy::class)
     fun printLog(msg: String)
 }

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategy.java
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategy.java
@@ -1,7 +1,10 @@
 package example.com.androidxsample.view.migration;
 
 import moxy.MvpView;
+import moxy.viewstate.strategy.OneExecutionStateStrategy;
+import moxy.viewstate.strategy.StateStrategyType;
 
+@StateStrategyType(OneExecutionStateStrategy.class)
 public interface ViewWithoutStrategy extends MvpView {
 
     void noStrategyMethod();

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategy.java
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategy.java
@@ -1,0 +1,8 @@
+package example.com.androidxsample.view.migration;
+
+import moxy.MvpView;
+
+public interface ViewWithoutStrategy extends MvpView {
+
+    void noStrategyMethod();
+}

--- a/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategyPresenter.java
+++ b/sample-app/src/main/kotlin/example/com/androidxsample/view/migration/ViewWithoutStrategyPresenter.java
@@ -1,0 +1,9 @@
+package example.com.androidxsample.view.migration;
+
+import moxy.InjectViewState;
+import moxy.MvpPresenter;
+
+@InjectViewState
+public class ViewWithoutStrategyPresenter extends MvpPresenter<ViewWithoutStrategy> {
+
+}


### PR DESCRIPTION
1) Поменял поведение по умолчанию: теперь методы без дефолтной стратегии будут вызывать ошибки компиляции.
2) Добавил опцию компилятора, чтобы пустую стратегию можно было использовать.
3) Поменял стратегию по умолчанию для таких случаев с AddToEndStrategy на AddToEndSingleStrategy; 
4) Добавил возможность самому устанавливать стратегию по умолчанию.
5) Добавил два механизма для миграции со старого поведения, так как через ошибки компилятора неудобно делать много правок. Это теперь можно будет сделать через генерацию специального класса EmptyStrategyHelper