### PR TITLE
Fix inherited method being written twice inside generated ViewState when using modifiers

### DIFF
--- a/moxy-compiler/src/main/java/moxy/compiler/Util.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/Util.java
@@ -16,10 +16,16 @@
  */
 package moxy.compiler;
 
+import com.google.common.base.Preconditions;
+
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -196,5 +202,30 @@ public final class Util {
     public static String decapitalizeString(String string) {
         return string == null || string.isEmpty() ? "" : string.length()
             == 1 ? string.toLowerCase() : Character.toLowerCase(string.charAt(0)) + string.substring(1);
+    }
+
+    public static <T> boolean equalsBy(
+            Collection<T> first,
+            Collection<T> second,
+            BiFunction<T, T, Boolean> predicate) {
+
+        Preconditions.checkArgument(predicate != null, "Require non null predicate!");
+        if (first != null && second != null) {
+            if (first.size() != second.size()) {
+                return false;
+            }
+            final Iterator<T> firstIterator = first.iterator();
+            final Iterator<T> secondIterator = second.iterator();
+            while (firstIterator.hasNext()) {
+                final T firstItem = firstIterator.next();
+                final T secondItem = secondIterator.next();
+                if (!predicate.apply(firstItem, secondItem)) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return first != second;
+        }
     }
 }

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
@@ -142,7 +142,7 @@ class ViewMethod {
         ViewMethod that = (ViewMethod) o;
 
         return name.equals(that.name) && Util.equalsBy(this.parameterSpecs, that.parameterSpecs,
-                (first, second) -> Objects.equals(first.type,second.type));
+                (first, second) -> Objects.equals(first.type, second.type));
     }
 
     @Override

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
@@ -5,6 +5,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeVariableName;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -144,8 +145,13 @@ class ViewMethod {
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + parameterSpecs.hashCode();
+        if (name == null && parameterSpecs == null) {
+            return 0;
+        }
+        int result = 31 + Objects.hashCode(name);
+        for (ParameterSpec spec : parameterSpecs) {
+            result = 31 * result + (spec != null ? Objects.hashCode(spec.type) : 0);
+        }
         return result;
     }
 }

--- a/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstate/ViewMethod.java
@@ -15,6 +15,7 @@ import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import moxy.compiler.MvpCompiler;
+import moxy.compiler.Util;
 
 class ViewMethod {
 
@@ -140,7 +141,8 @@ class ViewMethod {
 
         ViewMethod that = (ViewMethod) o;
 
-        return name.equals(that.name) && parameterSpecs.equals(that.parameterSpecs);
+        return name.equals(that.name) && Util.equalsBy(this.parameterSpecs, that.parameterSpecs,
+                (first, second) -> Objects.equals(first.type,second.type));
     }
 
     @Override

--- a/moxy-compiler/src/test/resources/view/strategies_inheritance/ChildView$$State.java
+++ b/moxy-compiler/src/test/resources/view/strategies_inheritance/ChildView$$State.java
@@ -56,9 +56,56 @@ public class ChildView$$State extends MvpViewState<ChildView> implements ChildVi
     }
 
     @Override
+    public void parentMethodWithArg(final String i) {
+        ParentMethodWithArgCommand parentMethodWithArgCommand = new ParentMethodWithArgCommand(i);
+        viewCommands.beforeApply(parentMethodWithArgCommand);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ChildView view : views) {
+            view.parentMethodWithArg(i);
+        }
+
+        viewCommands.afterApply(parentMethodWithArgCommand);
+    }
+
+    @Override
+    public void parentMethodWithArg2(String i) {
+        ParentMethodWithArg2Command parentMethodWithArg2Command = new ParentMethodWithArg2Command(i);
+        viewCommands.beforeApply(parentMethodWithArg2Command);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ChildView view : views) {
+            view.parentMethodWithArg2(i);
+        }
+
+        viewCommands.afterApply(parentMethodWithArg2Command);
+    }
+
+    @Override
+    public void parentMethodWithArg3(String a) {
+        ParentMethodWithArg3Command parentMethodWithArg3Command = new ParentMethodWithArg3Command(a);
+        viewCommands.beforeApply(parentMethodWithArg3Command);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ChildView view : views) {
+            view.parentMethodWithArg3(a);
+        }
+
+        viewCommands.afterApply(parentMethodWithArg3Command);
+    }
+
+    @Override
     public void childMethodWithStrategy() {
-        ChildMethodWithStrategyCommand childMethodWithStrategyCommand =
-            new ChildMethodWithStrategyCommand();
+        ChildMethodWithStrategyCommand childMethodWithStrategyCommand = new ChildMethodWithStrategyCommand();
         viewCommands.beforeApply(childMethodWithStrategyCommand);
 
         if (hasNotView()) {
@@ -90,8 +137,7 @@ public class ChildView$$State extends MvpViewState<ChildView> implements ChildVi
 
     @Override
     public void parentMethodWithStrategy() {
-        ParentMethodWithStrategyCommand parentMethodWithStrategyCommand =
-            new ParentMethodWithStrategyCommand();
+        ParentMethodWithStrategyCommand parentMethodWithStrategyCommand = new ParentMethodWithStrategyCommand();
         viewCommands.beforeApply(parentMethodWithStrategyCommand);
 
         if (hasNotView()) {
@@ -135,6 +181,51 @@ public class ChildView$$State extends MvpViewState<ChildView> implements ChildVi
         @Override
         public void apply(ChildView mvpView) {
             mvpView.childMethod();
+        }
+    }
+
+    public class ParentMethodWithArgCommand extends ViewCommand<ChildView> {
+        public final String i;
+
+        ParentMethodWithArgCommand(final String i) {
+            super("parentMethodWithArg", ChildDefaultStrategy.class);
+
+            this.i = i;
+        }
+
+        @Override
+        public void apply(ChildView mvpView) {
+            mvpView.parentMethodWithArg(i);
+        }
+    }
+
+    public class ParentMethodWithArg2Command extends ViewCommand<ChildView> {
+        public final String i;
+
+        ParentMethodWithArg2Command(String i) {
+            super("parentMethodWithArg2", ChildDefaultStrategy.class);
+
+            this.i = i;
+        }
+
+        @Override
+        public void apply(ChildView mvpView) {
+            mvpView.parentMethodWithArg2(i);
+        }
+    }
+
+    public class ParentMethodWithArg3Command extends ViewCommand<ChildView> {
+        public final String a;
+
+        ParentMethodWithArg3Command(String a) {
+            super("parentMethodWithArg3", ChildDefaultStrategy.class);
+
+            this.a = a;
+        }
+
+        @Override
+        public void apply(ChildView mvpView) {
+            mvpView.parentMethodWithArg3(a);
         }
     }
 

--- a/moxy-compiler/src/test/resources/view/strategies_inheritance/ChildView.java
+++ b/moxy-compiler/src/test/resources/view/strategies_inheritance/ChildView.java
@@ -1,18 +1,27 @@
 package view.strategies_inheritance;
 
 import moxy.viewstate.strategy.StateStrategyType;
+
 import view.strategies_inheritance.strategies.ChildDefaultStrategy;
 import view.strategies_inheritance.strategies.Strategy2;
 
+import javax.annotation.Nullable;
+
 @StateStrategyType(ChildDefaultStrategy.class)
 public interface ChildView extends ParentView {
-
     void parentMethod1(); // ParentDefaultStrategy -> ChildDefaultStrategy
 
     @StateStrategyType(Strategy2.class)
     void parentMethod2(); // ParentDefaultStrategy -> Strategy2
 
     void childMethod(); // ChildDefaultStrategy
+
+    @Override
+    void parentMethodWithArg(final String i); // ParentDefaultStrategy -> ChildDefaultStrategy
+
+    void parentMethodWithArg2(@Nullable String i); // ParentDefaultStrategy
+
+    void parentMethodWithArg3(String a); // ParentDefaultStrategy
 
     @StateStrategyType(Strategy2.class)
     void childMethodWithStrategy(); // Strategy2

--- a/moxy-compiler/src/test/resources/view/strategies_inheritance/ParentView$$State.java
+++ b/moxy-compiler/src/test/resources/view/strategies_inheritance/ParentView$$State.java
@@ -1,12 +1,13 @@
 package view.strategies_inheritance;
 
+import java.lang.Override;
+import java.lang.String;
 import moxy.viewstate.MvpViewState;
 import moxy.viewstate.ViewCommand;
 import view.strategies_inheritance.strategies.ParentDefaultStrategy;
 import view.strategies_inheritance.strategies.Strategy1;
 
 public class ParentView$$State extends MvpViewState<ParentView> implements ParentView {
-
     @Override
     public void parentMethod1() {
         ParentMethod1Command parentMethod1Command = new ParentMethod1Command();
@@ -56,9 +57,56 @@ public class ParentView$$State extends MvpViewState<ParentView> implements Paren
     }
 
     @Override
+    public void parentMethodWithArg(String i) {
+        ParentMethodWithArgCommand parentMethodWithArgCommand = new ParentMethodWithArgCommand(i);
+        viewCommands.beforeApply(parentMethodWithArgCommand);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ParentView view : views) {
+            view.parentMethodWithArg(i);
+        }
+
+        viewCommands.afterApply(parentMethodWithArgCommand);
+    }
+
+    @Override
+    public void parentMethodWithArg2(String i) {
+        ParentMethodWithArg2Command parentMethodWithArg2Command = new ParentMethodWithArg2Command(i);
+        viewCommands.beforeApply(parentMethodWithArg2Command);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ParentView view : views) {
+            view.parentMethodWithArg2(i);
+        }
+
+        viewCommands.afterApply(parentMethodWithArg2Command);
+    }
+
+    @Override
+    public void parentMethodWithArg3(String i) {
+        ParentMethodWithArg3Command parentMethodWithArg3Command = new ParentMethodWithArg3Command(i);
+        viewCommands.beforeApply(parentMethodWithArg3Command);
+
+        if (hasNotView()) {
+            return;
+        }
+
+        for (ParentView view : views) {
+            view.parentMethodWithArg3(i);
+        }
+
+        viewCommands.afterApply(parentMethodWithArg3Command);
+    }
+
+    @Override
     public void parentMethodWithStrategy() {
-        ParentMethodWithStrategyCommand parentMethodWithStrategyCommand =
-                new ParentMethodWithStrategyCommand();
+        ParentMethodWithStrategyCommand parentMethodWithStrategyCommand = new ParentMethodWithStrategyCommand();
         viewCommands.beforeApply(parentMethodWithStrategyCommand);
 
         if (hasNotView()) {
@@ -73,7 +121,6 @@ public class ParentView$$State extends MvpViewState<ParentView> implements Paren
     }
 
     public class ParentMethod1Command extends ViewCommand<ParentView> {
-
         ParentMethod1Command() {
             super("parentMethod1", ParentDefaultStrategy.class);
         }
@@ -85,7 +132,6 @@ public class ParentView$$State extends MvpViewState<ParentView> implements Paren
     }
 
     public class ParentMethod2Command extends ViewCommand<ParentView> {
-
         ParentMethod2Command() {
             super("parentMethod2", ParentDefaultStrategy.class);
         }
@@ -97,7 +143,6 @@ public class ParentView$$State extends MvpViewState<ParentView> implements Paren
     }
 
     public class ParentMethod3Command extends ViewCommand<ParentView> {
-
         ParentMethod3Command() {
             super("parentMethod3", ParentDefaultStrategy.class);
         }
@@ -108,8 +153,52 @@ public class ParentView$$State extends MvpViewState<ParentView> implements Paren
         }
     }
 
-    public class ParentMethodWithStrategyCommand extends ViewCommand<ParentView> {
+    public class ParentMethodWithArgCommand extends ViewCommand<ParentView> {
+        public final String i;
 
+        ParentMethodWithArgCommand(String i) {
+            super("parentMethodWithArg", ParentDefaultStrategy.class);
+
+            this.i = i;
+        }
+
+        @Override
+        public void apply(ParentView mvpView) {
+            mvpView.parentMethodWithArg(i);
+        }
+    }
+
+    public class ParentMethodWithArg2Command extends ViewCommand<ParentView> {
+        public final String i;
+
+        ParentMethodWithArg2Command(String i) {
+            super("parentMethodWithArg2", ParentDefaultStrategy.class);
+
+            this.i = i;
+        }
+
+        @Override
+        public void apply(ParentView mvpView) {
+            mvpView.parentMethodWithArg2(i);
+        }
+    }
+
+    public class ParentMethodWithArg3Command extends ViewCommand<ParentView> {
+        public final String i;
+
+        ParentMethodWithArg3Command(String i) {
+            super("parentMethodWithArg3", ParentDefaultStrategy.class);
+
+            this.i = i;
+        }
+
+        @Override
+        public void apply(ParentView mvpView) {
+            mvpView.parentMethodWithArg3(i);
+        }
+    }
+
+    public class ParentMethodWithStrategyCommand extends ViewCommand<ParentView> {
         ParentMethodWithStrategyCommand() {
             super("parentMethodWithStrategy", Strategy1.class);
         }

--- a/moxy-compiler/src/test/resources/view/strategies_inheritance/ParentView.java
+++ b/moxy-compiler/src/test/resources/view/strategies_inheritance/ParentView.java
@@ -2,17 +2,23 @@ package view.strategies_inheritance;
 
 import moxy.MvpView;
 import moxy.viewstate.strategy.StateStrategyType;
+
 import view.strategies_inheritance.strategies.ParentDefaultStrategy;
 import view.strategies_inheritance.strategies.Strategy1;
 
 @StateStrategyType(ParentDefaultStrategy.class)
 public interface ParentView extends MvpView {
-
     void parentMethod1(); // ParentDefaultStrategy
 
     void parentMethod2(); // ParentDefaultStrategy
 
     void parentMethod3(); // ParentDefaultStrategy
+
+    void parentMethodWithArg(String i); // ParentDefaultStrategy
+
+    void parentMethodWithArg2(String i); // ParentDefaultStrategy
+
+    void parentMethodWithArg3(String i); // ParentDefaultStrategy
 
     @StateStrategyType(Strategy1.class)
     void parentMethodWithStrategy(); // Strategy1


### PR DESCRIPTION
Latest version of Moxy compare interface methods with superclass methods using `TypeSpec#equal(Object)`, which leads to methods not being equal when we rename parameter in overriden method or add modifier to it (`final` for example). This leads to those methods are generated multiple times inside `ViewState` which breaks build. I change this logic to compare methods only be name and parameter types sequentially. 