### PR TITLE
Fix broken code generation when view interface is inside other class\…

### DIFF
--- a/moxy-compiler/src/main/java/moxy/compiler/Util.java
+++ b/moxy-compiler/src/main/java/moxy/compiler/Util.java
@@ -118,6 +118,16 @@ public final class Util {
         return packageName + className.replaceAll("\\.", "\\$");
     }
 
+    public static String getSimpleClassName(TypeElement typeElement) {
+        String packageName = MvpCompiler.getElementUtils().getPackageOf(typeElement).getQualifiedName().toString();
+        if (packageName.length() > 0) {
+            packageName += ".";
+        }
+
+        String className = typeElement.toString().substring(packageName.length());
+        return className.replaceAll("\\.", "\\$");
+    }
+
     public static AnnotationMirror getAnnotation(Element element, String annotationClass) {
         for (AnnotationMirror annotationMirror : element.getAnnotationMirrors()) {
             if (annotationMirror.getAnnotationType().asElement().toString().equals(annotationClass)) {

--- a/moxy-compiler/src/test/java/moxy/compiler/NestedViewTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/NestedViewTest.java
@@ -1,0 +1,25 @@
+package moxy.compiler;
+
+import com.google.testing.compile.Compilation;
+
+import org.junit.Test;
+
+import javax.tools.JavaFileObject;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.JavaFileObjects.forResource;
+import static org.junit.Assert.assertEquals;
+
+public class NestedViewTest extends CompilerTest {
+    @Test
+    public void testNestedViewCompilesWithoutErrors() throws Exception {
+        JavaFileObject[] sources = {
+                forResource("nestedview/MyContract.java"),
+                forResource("nestedview/MyPresenter.java")
+        };
+
+        Compilation compilation = compileLibSourcesWithProcessor(sources);
+        assertThat(compilation).succeeded();
+        assertEquals(2, compilation.generatedSourceFiles().size());
+    }
+}

--- a/moxy-compiler/src/test/resources/nestedview/MyContract.java
+++ b/moxy-compiler/src/test/resources/nestedview/MyContract.java
@@ -1,0 +1,11 @@
+import moxy.MvpView;
+import moxy.viewstate.strategy.OneExecutionStateStrategy;
+import moxy.viewstate.strategy.StateStrategyType;
+
+public interface MyContract {
+
+    @StateStrategyType(OneExecutionStateStrategy.class)
+    public interface View extends MvpView {
+        void someMethod();
+    }
+}

--- a/moxy-compiler/src/test/resources/nestedview/MyPresenter.java
+++ b/moxy-compiler/src/test/resources/nestedview/MyPresenter.java
@@ -1,0 +1,6 @@
+import moxy.InjectViewState;
+import moxy.MvpPresenter;
+
+@InjectViewState
+class MyPresenter extends MvpPresenter<MyContract.View> {
+}


### PR DESCRIPTION
Исправил ошибку, когда если интерфейс View находился внутри другого класса, то названия сгенерированного ViewState отличались, что приводило к ошибке компиляции. И добавил тест на этот кейс.