### PR TITLE
Fix restoration of childDelegate delegateTag

### DIFF
--- a/moxy/src/main/java/moxy/MvpDelegate.java
+++ b/moxy/src/main/java/moxy/MvpDelegate.java
@@ -202,6 +202,7 @@ public class MvpDelegate<Delegated> {
         childDelegatesClone.addAll(childDelegates);
 
         for (MvpDelegate childDelegate : childDelegatesClone) {
+            childDelegate.onSaveInstanceState();
             childDelegate.onDestroyView();
         }
 


### PR DESCRIPTION
Problem: the only way for `childDelegate` to save its `delegateTag` is to call `onSaveInstanceState()`
However, this method is not called in `Fragment` when fragment goes to backStack.

So, I'm calling `MvpDelegate.onSaveInstanceState()` manually on each `childDelegate` in `MvpDelegate.onDestroyView()` method since after calling this method `childDelegate` become destroyed and losing its connection to `parentDelegate`