### PR TITLE
Rethrow exceptions in ViewStateLocator

### DIFF
--- a/moxy/src/main/java/moxy/locators/ViewStateLocator.java
+++ b/moxy/src/main/java/moxy/locators/ViewStateLocator.java
@@ -15,7 +15,7 @@ public class ViewStateLocator {
             Class<? extends ViewStateProvider> aClass = (Class<? extends ViewStateProvider>) Class.forName(className);
             return aClass.newInstance().getViewState();
         } catch (Exception e) {
-            return null;
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Consider this situation:

1. `MvpPresenter.Binder.bind` calls `ViewStateLocator.getViewState`
2. Inside `ViewStateLocator.getViewState` a call to `Class.forName` for some reason raises an exception
2. `ViewStateLocator.getViewState` silently consumes this exception and returns null
3. Later on we get NPE when calling something like `viewState.showMessage()` in presenter. The reason for NPE is unclear and difficult to debug.

I propose not to silently consume exception.