### PR TITLE
Generate view state providers for nested presenters

### DIFF
--- a/moxy-compiler/src/main/java/moxy/compiler/viewstateprovider/ViewStateProviderClassGenerator.kt
+++ b/moxy-compiler/src/main/java/moxy/compiler/viewstateprovider/ViewStateProviderClassGenerator.kt
@@ -18,8 +18,16 @@ import javax.lang.model.element.Modifier
 class ViewStateProviderClassGenerator : JavaFilesGenerator<PresenterInfo> {
 
     override fun generate(presenterInfo: PresenterInfo): List<JavaFile> {
+        var className = presenterInfo.name.simpleName() + MvpProcessor.VIEW_STATE_PROVIDER_SUFFIX
+        var enclosingClass = presenterInfo.name.enclosingClassName()
+
+        while (enclosingClass != null) {
+            className = "${enclosingClass.simpleName()}$$className"
+            enclosingClass = enclosingClass.enclosingClassName()
+        }
+
         val typeSpec = TypeSpec
-            .classBuilder(presenterInfo.name.simpleName() + MvpProcessor.VIEW_STATE_PROVIDER_SUFFIX)
+            .classBuilder(className)
             .addModifiers(Modifier.PUBLIC)
             .superclass(ViewStateProvider::class.java)
             .addMethod(presenterInfo.generateGetViewStateMethod())

--- a/moxy-compiler/src/test/java/moxy/compiler/NestedPresenterViewStateProviderTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/NestedPresenterViewStateProviderTest.java
@@ -1,0 +1,54 @@
+package moxy.compiler;
+
+import com.google.testing.compile.Compilation;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.tools.JavaFileObject;
+
+import moxy.MvpProcessor;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+@RunWith(Parameterized.class)
+public class NestedPresenterViewStateProviderTest extends CompilerTest {
+
+    @Parameterized.Parameter
+    public TestParams testParams;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static TestParams[] data() {
+        return new TestParams[] {
+            new TestParams(
+                "presenter.PresenterWrapper",
+                "presenter.PresenterWrapper$EmptyViewPresenter" + MvpProcessor.VIEW_STATE_PROVIDER_SUFFIX
+            ),
+        };
+    }
+
+    @Test
+    public void test() throws Exception {
+        JavaFileObject presenter = getSourceFile(testParams.sourceFileName);
+        JavaFileObject exceptedViewStateProvider = getSourceFile(testParams.compiledFileName);
+
+        Compilation presenterCompilation = compileSourcesWithProcessor(presenter);
+        Compilation exceptedViewStateProviderCompilation =
+            compileSources(exceptedViewStateProvider);
+
+        assertThat(presenterCompilation).succeeded();
+        assertExceptedFilesGenerated(presenterCompilation.generatedFiles(),
+            exceptedViewStateProviderCompilation.generatedFiles());
+    }
+
+    private static class TestParams {
+        final String sourceFileName;
+        final String compiledFileName;
+
+        TestParams(String sourceFileName, String compiledFileName) {
+            this.sourceFileName = sourceFileName;
+            this.compiledFileName = compiledFileName;
+        }
+    }
+}

--- a/moxy-compiler/src/test/resources/presenter/PresenterWrapper$EmptyViewPresenter$$ViewStateProvider.java
+++ b/moxy-compiler/src/test/resources/presenter/PresenterWrapper$EmptyViewPresenter$$ViewStateProvider.java
@@ -1,0 +1,14 @@
+package presenter;
+
+import moxy.MvpView;
+import moxy.ViewStateProvider;
+import moxy.viewstate.MvpViewState;
+import view.EmptyView$$State;
+
+public class PresenterWrapper$EmptyViewPresenter$$ViewStateProvider extends ViewStateProvider {
+
+    @Override
+    public MvpViewState<? extends MvpView> getViewState() {
+        return new EmptyView$$State();
+    }
+}

--- a/moxy-compiler/src/test/resources/presenter/PresenterWrapper.java
+++ b/moxy-compiler/src/test/resources/presenter/PresenterWrapper.java
@@ -1,0 +1,11 @@
+package presenter;
+
+import moxy.InjectViewState;
+import moxy.MvpPresenter;
+import view.EmptyView;
+
+class PresenterWrapper {
+    @InjectViewState
+    public static class EmptyViewPresenter extends MvpPresenter<EmptyView> {
+    }
+}


### PR DESCRIPTION
Currently, moxy compiler doesn't generate correct ViewStateProvider classes for nested presenters, which leads to a NPE at runtime when trying to access view state.

By "nested" I mean defined in an interface or another class:

```
class SomeClass {
    class MainPresenter : MvpPresenter<MainView>() {
        ...
    }
}
```

or

```
interface SomeInterface {
    class MainPresenter : MvpPresenter<MainView>() {
        ...
    }
}
```

We can easily fix this by taking into account enclosing classes.

The proposed solution doesn't break anything and works for both nested and non-nested presenters.

This is a new pull request following the discussion in https://github.com/moxy-community/Moxy/pull/106
For some reason github wouldn't update my first pull request even though I updated my branch, hence I closed https://github.com/moxy-community/Moxy/pull/106 and created this new PR.