### PR TITLE
Fix typos in variable names: "excepted" => "expected"

### DIFF
--- a/moxy-compiler/src/test/java/moxy/compiler/CompilerTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/CompilerTest.java
@@ -41,14 +41,14 @@ public abstract class CompilerTest {
     }
 
     /**
-     * Asserts that all files from {@code exceptedGeneratedFiles} exists in {@code
+     * Asserts that all files from {@code expectedGeneratedFiles} exists in {@code
      * actualGeneratedFiles}
      * and have equivalent bytecode
      */
-    protected void assertExceptedFilesGenerated(List<JavaFileObject> actualGeneratedFiles,
-        List<JavaFileObject> exceptedGeneratedFiles) throws Exception {
-        for (JavaFileObject exceptedClass : exceptedGeneratedFiles) {
-            final String fileName = exceptedClass.getName();
+    protected void assertExpectedFilesGenerated(List<JavaFileObject> actualGeneratedFiles,
+        List<JavaFileObject> expectedGeneratedFiles) throws Exception {
+        for (JavaFileObject expectedClass : expectedGeneratedFiles) {
+            final String fileName = expectedClass.getName();
 
             JavaFileObject actualClass = actualGeneratedFiles.stream()
                 .filter(input -> fileName.equals(input.getName()))
@@ -56,20 +56,20 @@ public abstract class CompilerTest {
                 .orElseThrow(() -> new AssertionFailedError("File " + fileName + " is not generated"));
 
             String actualBytecode = getBytecodeString(actualClass);
-            String exceptedBytecode = getBytecodeString(exceptedClass);
+            String expectedBytecode = getBytecodeString(expectedClass);
 
-            if (!exceptedBytecode.equals(actualBytecode)) {
+            if (!expectedBytecode.equals(actualBytecode)) {
                 JavaFileObject actualSource = findSourceForClass(actualGeneratedFiles, fileName);
 
                 throw new ComparisonFailure(Joiner.on('\n').join(
-                    "Bytecode for file " + fileName + " not equal to excepted",
+                    "Bytecode for file " + fileName + " not equal to expected",
                     "",
                     "Actual generated file (" + actualSource.getName() + "):",
                     "================",
                     "",
                     actualSource.getCharContent(false),
                     ""
-                ), exceptedBytecode, actualBytecode);
+                ), expectedBytecode, actualBytecode);
             }
         }
     }

--- a/moxy-compiler/src/test/java/moxy/compiler/MultiModulesTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/MultiModulesTest.java
@@ -22,10 +22,10 @@ public class MultiModulesTest extends CompilerTest {
         };
 
         Compilation compilation = compileLibSourcesWithProcessor(sources);
-        Compilation exceptedCompilation = compileSources(generatedSources);
+        Compilation expectedCompilation = compileSources(generatedSources);
 
         assertThat(compilation).succeededWithoutWarnings();
-        assertExceptedFilesGenerated(compilation.generatedFiles(),
-            exceptedCompilation.generatedFiles());
+        assertExpectedFilesGenerated(compilation.generatedFiles(),
+            expectedCompilation.generatedFiles());
     }
 }

--- a/moxy-compiler/src/test/java/moxy/compiler/NestedPresenterViewStateProviderTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/NestedPresenterViewStateProviderTest.java
@@ -31,15 +31,15 @@ public class NestedPresenterViewStateProviderTest extends CompilerTest {
     @Test
     public void test() throws Exception {
         JavaFileObject presenter = getSourceFile(testParams.sourceFileName);
-        JavaFileObject exceptedViewStateProvider = getSourceFile(testParams.compiledFileName);
+        JavaFileObject expectedViewStateProvider = getSourceFile(testParams.compiledFileName);
 
         Compilation presenterCompilation = compileSourcesWithProcessor(presenter);
-        Compilation exceptedViewStateProviderCompilation =
-            compileSources(exceptedViewStateProvider);
+        Compilation expectedViewStateProviderCompilation =
+            compileSources(expectedViewStateProvider);
 
         assertThat(presenterCompilation).succeeded();
-        assertExceptedFilesGenerated(presenterCompilation.generatedFiles(),
-            exceptedViewStateProviderCompilation.generatedFiles());
+        assertExpectedFilesGenerated(presenterCompilation.generatedFiles(),
+            expectedViewStateProviderCompilation.generatedFiles());
     }
 
     private static class TestParams {

--- a/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderErrorTestKt.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderErrorTestKt.kt
@@ -69,7 +69,7 @@ class PresentersBinderErrorTestKt : CompilerTest() {
         val compilation = compileSourcesWithProcessor(view, presenter)
         val expectedCompilation = compileSources(view, presenter, expected)
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             expectedCompilation.generatedFiles())
     }

--- a/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderTagTest.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderTagTest.kt
@@ -39,7 +39,7 @@ class PresentersBinderTagTest : CompilerTest() {
 
         val compilation = compileSourcesWithProcessor(target, presenter)
         compilation.assertSucceededWithoutWarnings()
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(target, presenter, expected).generatedFiles())
     }
@@ -69,7 +69,7 @@ class PresentersBinderTagTest : CompilerTest() {
 
         val compilation = compileSourcesWithProcessor(target, presenter)
         compilation.assertSucceededWithoutWarnings()
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(target, presenter, expected).generatedFiles())
     }
@@ -99,7 +99,7 @@ class PresentersBinderTagTest : CompilerTest() {
 
         val compilation = compileSourcesWithProcessor(target, presenter)
         compilation.assertSucceededWithoutWarnings()
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(target, presenter, expected).generatedFiles())
     }
@@ -129,7 +129,7 @@ class PresentersBinderTagTest : CompilerTest() {
 
         val compilation = compileSourcesWithProcessor(target, presenter)
         compilation.assertSucceededWithoutWarnings()
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(target, presenter, expected).generatedFiles())
     }

--- a/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/PresentersBinderTest.java
@@ -27,14 +27,14 @@ public class PresentersBinderTest extends CompilerTest {
     @Test
     public void test() throws Exception {
         JavaFileObject target = getSourceFile(targetClassName);
-        JavaFileObject exceptedPresentersBinder =
+        JavaFileObject expectedPresentersBinder =
             getSourceFile(targetClassName + MvpProcessor.PRESENTER_BINDER_SUFFIX);
 
         Compilation targetCompilation = compileSourcesWithProcessor(target);
-        Compilation exceptedPresentersBinderCompilation = compileSources(exceptedPresentersBinder);
+        Compilation expectedPresentersBinderCompilation = compileSources(expectedPresentersBinder);
 
         assertThat(targetCompilation).succeededWithoutWarnings();
-        assertExceptedFilesGenerated(targetCompilation.generatedFiles(),
-            exceptedPresentersBinderCompilation.generatedFiles());
+        assertExpectedFilesGenerated(targetCompilation.generatedFiles(),
+            expectedPresentersBinderCompilation.generatedFiles());
     }
 }

--- a/moxy-compiler/src/test/java/moxy/compiler/StrategyAliasTest.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/StrategyAliasTest.kt
@@ -87,7 +87,7 @@ class StrategyAliasTest : CompilerTest() {
 
         val expectedCompilation = compileSources(viewInterface, presenter, expected)
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             expectedCompilation.generatedFiles())
     }
@@ -118,7 +118,7 @@ class StrategyAliasTest : CompilerTest() {
 
         val expectedCompilation = compileSources(viewInterface, presenter, expected)
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             expectedCompilation.generatedFiles())
     }
@@ -146,7 +146,7 @@ class StrategyAliasTest : CompilerTest() {
 
         val expectedCompilation = compileSources(viewInterface, presenter, expected)
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             expectedCompilation.generatedFiles())
     }

--- a/moxy-compiler/src/test/java/moxy/compiler/ViewStateNegativeTestKt.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/ViewStateNegativeTestKt.kt
@@ -53,7 +53,7 @@ class ViewStateNegativeTestKt : CompilerTest() {
         val presenterCompilation = compileSourcesWithProcessor(presenter, view)
         val viewStateCompilation = compileSources(view, expected)
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
                 presenterCompilation.generatedFiles(),
                 viewStateCompilation.generatedFiles())
     }

--- a/moxy-compiler/src/test/java/moxy/compiler/ViewStateProviderTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/ViewStateProviderTest.java
@@ -26,15 +26,15 @@ public class ViewStateProviderTest extends CompilerTest {
     @Test
     public void test() throws Exception {
         JavaFileObject presenter = getSourceFile(presenterClassName);
-        JavaFileObject exceptedViewStateProvider = getSourceFile(
+        JavaFileObject expectedViewStateProvider = getSourceFile(
             presenterClassName + MvpProcessor.VIEW_STATE_PROVIDER_SUFFIX);
 
         Compilation presenterCompilation = compileSourcesWithProcessor(presenter);
-        Compilation exceptedViewStateProviderCompilation =
-            compileSources(exceptedViewStateProvider);
+        Compilation expectedViewStateProviderCompilation =
+            compileSources(expectedViewStateProvider);
 
         assertThat(presenterCompilation).succeeded(); // TODO: assert no warnings
-        assertExceptedFilesGenerated(presenterCompilation.generatedFiles(),
-            exceptedViewStateProviderCompilation.generatedFiles());
+        assertExpectedFilesGenerated(presenterCompilation.generatedFiles(),
+            expectedViewStateProviderCompilation.generatedFiles());
     }
 }

--- a/moxy-compiler/src/test/java/moxy/compiler/ViewStateTest.java
+++ b/moxy-compiler/src/test/java/moxy/compiler/ViewStateTest.java
@@ -35,15 +35,15 @@ public class ViewStateTest extends CompilerTest {
     @Test
     public void test() throws Exception {
         JavaFileObject presenter = createDummyPresenter(viewClassName);
-        JavaFileObject exceptedViewState =
+        JavaFileObject expectedViewState =
             getSourceFile(viewClassName + MvpProcessor.VIEW_STATE_SUFFIX);
 
         Compilation presenterCompilation = compileSourcesWithProcessor(presenter);
-        Compilation exceptedViewStateCompilation = compileSources(exceptedViewState);
+        Compilation expectedViewStateCompilation = compileSources(expectedViewState);
 
         assertThat(presenterCompilation).succeededWithoutWarnings();
-        assertExceptedFilesGenerated(presenterCompilation.generatedFiles(),
-            exceptedViewStateCompilation.generatedFiles());
+        assertExpectedFilesGenerated(presenterCompilation.generatedFiles(),
+            expectedViewStateCompilation.generatedFiles());
     }
 
     private JavaFileObject createDummyPresenter(String viewClass) {

--- a/moxy-compiler/src/test/java/moxy/compiler/ViewStateTestKt.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/ViewStateTestKt.kt
@@ -90,7 +90,7 @@ class ViewStateTestKt : CompilerTest() {
         val compilation = compileSourcesWithProcessor(view, generateViewStateFor("TaggedView"))
         compilation.assertSucceededWithoutWarnings()
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(view, expected).generatedFiles()
         )
@@ -176,7 +176,7 @@ class ViewStateTestKt : CompilerTest() {
         val compilation = compileSourcesWithProcessor(view, generateViewStateFor(view.name.substringBefore('.')))
         compilation.assertSucceededWithoutWarnings()
 
-        assertExceptedFilesGenerated(
+        assertExpectedFilesGenerated(
             compilation.generatedFiles(),
             compileSources(view, expected).generatedFiles()
         )


### PR DESCRIPTION
Following the discussion in https://github.com/moxy-community/Moxy/pull/108 I replaced all occurrences of "excepted" with "expected", the tests run fine. I manually ran through the diff, everything seems fine.