### PR TITLE
Support tags in state strategy aliases 

### DIFF
--- a/moxy-compiler/src/main/java/moxy/compiler/Extensions.kt
+++ b/moxy-compiler/src/main/java/moxy/compiler/Extensions.kt
@@ -1,16 +1,7 @@
 package moxy.compiler
 
-import com.squareup.javapoet.ClassName
-import com.squareup.javapoet.JavaFile
-import com.squareup.javapoet.ParameterSpec
-import com.squareup.javapoet.ParameterizedTypeName
-import com.squareup.javapoet.TypeName
-import com.squareup.javapoet.TypeSpec
-import com.squareup.javapoet.TypeVariableName
-import com.squareup.javapoet.WildcardTypeName
-import javax.lang.model.element.AnnotationMirror
-import javax.lang.model.element.Element
-import javax.lang.model.element.TypeElement
+import com.squareup.javapoet.*
+import javax.lang.model.element.*
 import javax.lang.model.type.DeclaredType
 import javax.lang.model.type.TypeMirror
 import kotlin.contracts.ExperimentalContracts
@@ -21,7 +12,7 @@ import kotlin.reflect.KProperty1
 /**
  * TypeMirror must be of kind TypeKind.DECLARED
  */
-@UseExperimental(ExperimentalContracts::class)
+@OptIn(ExperimentalContracts::class)
 fun TypeMirror.asTypeElement(): TypeElement {
     contract {
         returns() implies (this@asTypeElement is DeclaredType)
@@ -45,8 +36,8 @@ fun ClassName.supertypeWildcard(): WildcardTypeName = WildcardTypeName.supertype
 fun TypeSpec.toJavaFile(className: ClassName): JavaFile = toJavaFile(className.packageName())
 fun TypeSpec.toJavaFile(packageName: String): JavaFile {
     return JavaFile.builder(packageName, this)
-        .indent("\t")
-        .build()
+            .indent("\t")
+            .build()
 }
 
 fun <T : Annotation> Element.getAnnotationMirror(type: KClass<T>): AnnotationMirror? {
@@ -74,4 +65,15 @@ fun List<ParameterSpec>.equalsByType(other: List<ParameterSpec>): Boolean {
     return Util.equalsBy(this, other) { first, second ->
         first.type == second.type
     }
+}
+
+fun TypeElement.getNonStaticMethods(): Set<ExecutableElement> {
+    return enclosedElements
+            .filter { it.kind == ElementKind.METHOD && !it.isStatic() }
+            .map { it as ExecutableElement }
+            .toSet()
+}
+
+private fun Element.isStatic(): Boolean {
+    return modifiers.contains(Modifier.STATIC)
 }

--- a/moxy-compiler/src/main/java/moxy/compiler/Extensions.kt
+++ b/moxy-compiler/src/main/java/moxy/compiler/Extensions.kt
@@ -58,6 +58,11 @@ fun AnnotationMirror.getValueAsString(property: KProperty1<*, *>): String? {
     return Util.getAnnotationValueAsString(this, property.name)
 }
 
+// Pass property name string
+fun AnnotationMirror.getValueAsString(propertyName: String): String? {
+    return Util.getAnnotationValueAsString(this, propertyName)
+}
+
 // Pass property name, like StateStrategyType::value
 fun AnnotationMirror.getValueAsTypeMirror(property: KProperty1<*, *>): TypeMirror? {
     return Util.getAnnotationValueAsTypeMirror(this, property.name)

--- a/moxy-compiler/src/test/java/moxy/compiler/StrategyAliasTest.kt
+++ b/moxy-compiler/src/test/java/moxy/compiler/StrategyAliasTest.kt
@@ -82,10 +82,10 @@ class StrategyAliasTest : CompilerTest() {
 
         val expected = GENERATED_VIEW_INTERFACE_WITH_ONE_EXECUTION_TEST_METHOD
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
-        val expectedCompilation = compileSources(viewInterface, presenter, expected)
+        val expectedCompilation = compileSources(viewInterface, viewState, expected)
 
         assertExpectedFilesGenerated(
             compilation.generatedFiles(),
@@ -116,10 +116,10 @@ class StrategyAliasTest : CompilerTest() {
 
         val expected = generateViewInterfaceWithOneExecutionTestMethod("testTag")
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
-        val expectedCompilation = compileSources(viewInterface, presenter, expected)
+        val expectedCompilation = compileSources(viewInterface, viewState, expected)
 
         assertExpectedFilesGenerated(
             compilation.generatedFiles(),
@@ -150,10 +150,10 @@ class StrategyAliasTest : CompilerTest() {
 
         val expected = GENERATED_VIEW_INTERFACE_WITH_ONE_EXECUTION_TEST_METHOD
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
-        val expectedCompilation = compileSources(viewInterface, presenter, expected)
+        val expectedCompilation = compileSources(viewInterface, viewState, expected)
 
         assertExpectedFilesGenerated(
             compilation.generatedFiles(),
@@ -185,13 +185,11 @@ class StrategyAliasTest : CompilerTest() {
             }
         """.toJavaFile()
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
         compilation.assertThatIt()
-            .hadErrorContaining("""
-                Annotation @StateStrategyTypeTag can't be applied to more than one method!
-            """.trimIndent())
+            .hadErrorContaining("Annotation @StateStrategyTypeTag can't be applied to more than one method!")
             .inFile(viewInterface)
             .onLineContaining("@interface OneExecution")
     }
@@ -218,8 +216,8 @@ class StrategyAliasTest : CompilerTest() {
             }
         """.toJavaFile()
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
         compilation.assertThatIt()
             .hadErrorContaining("Annotation @StateStrategyTypeTag can only be applied to method returning String!")
@@ -248,10 +246,10 @@ class StrategyAliasTest : CompilerTest() {
 
         val expected = GENERATED_VIEW_INTERFACE_WITH_ONE_EXECUTION_TEST_METHOD
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
-        val expectedCompilation = compileSources(viewInterface, presenter, expected)
+        val expectedCompilation = compileSources(viewInterface, viewState, expected)
 
         assertExpectedFilesGenerated(
             compilation.generatedFiles(),
@@ -276,10 +274,10 @@ class StrategyAliasTest : CompilerTest() {
 
         val expected = GENERATED_VIEW_INTERFACE_WITH_ONE_EXECUTION_TEST_METHOD
 
-        val presenter = generateViewStateFor("moxy.ViewInterface")
-        val compilation = compileSourcesWithProcessor(viewInterface, presenter)
+        val viewState = generateViewStateFor("moxy.ViewInterface")
+        val compilation = compileSourcesWithProcessor(viewInterface, viewState)
 
-        val expectedCompilation = compileSources(viewInterface, presenter, expected)
+        val expectedCompilation = compileSources(viewInterface, viewState, expected)
 
         assertExpectedFilesGenerated(
             compilation.generatedFiles(),

--- a/moxy/src/main/java/moxy/viewstate/strategy/StateStrategyTypeTag.java
+++ b/moxy/src/main/java/moxy/viewstate/strategy/StateStrategyTypeTag.java
@@ -1,0 +1,11 @@
+package moxy.viewstate.strategy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = { ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface StateStrategyTypeTag {
+}

--- a/moxy/src/main/java/moxy/viewstate/strategy/alias/AddToEndSingleTag.java
+++ b/moxy/src/main/java/moxy/viewstate/strategy/alias/AddToEndSingleTag.java
@@ -12,7 +12,7 @@ import moxy.viewstate.strategy.StateStrategyTypeTag;
 /**
  * State strategy alias for {@link moxy.viewstate.strategy.AddToEndSingleTagStrategy}.
  * Applying this annotation has the same effect as applying
- * {@code @StateStrategyType(AddToEndSingleTagStrategy.class, tag = "someTag)}.
+ * {@code @StateStrategyType(AddToEndSingleTagStrategy.class, tag = "someTag")}.
  * <br><br>
  * Command will be added to the end of the commands queue. If the commands queue contains the same tag, then
  * an existing command will be removed.

--- a/moxy/src/main/java/moxy/viewstate/strategy/alias/AddToEndSingleTag.java
+++ b/moxy/src/main/java/moxy/viewstate/strategy/alias/AddToEndSingleTag.java
@@ -1,0 +1,27 @@
+package moxy.viewstate.strategy.alias;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import moxy.viewstate.strategy.AddToEndSingleStrategy;
+import moxy.viewstate.strategy.StateStrategyType;
+import moxy.viewstate.strategy.StateStrategyTypeTag;
+
+/**
+ * State strategy alias for {@link moxy.viewstate.strategy.AddToEndSingleTagStrategy}.
+ * Applying this annotation has the same effect as applying
+ * {@code @StateStrategyType(AddToEndSingleTagStrategy.class, tag = "someTag)}.
+ * <br><br>
+ * Command will be added to the end of the commands queue. If the commands queue contains the same tag, then
+ * an existing command will be removed.
+ */
+@Target(value = {ElementType.TYPE, ElementType.METHOD})
+@Retention(value = RetentionPolicy.RUNTIME)
+@StateStrategyType(AddToEndSingleStrategy.class)
+public @interface AddToEndSingleTag {
+
+    @StateStrategyTypeTag
+    String tag() default "";
+}

--- a/sample-app/src/main/kotlin/moxy/sample/dailypicture/ui/DailyPictureView.kt
+++ b/sample-app/src/main/kotlin/moxy/sample/dailypicture/ui/DailyPictureView.kt
@@ -5,6 +5,7 @@ import moxy.sample.dailypicture.domain.PictureOfTheDay
 import moxy.viewstate.strategy.AddToEndSingleTagStrategy
 import moxy.viewstate.strategy.StateStrategyType
 import moxy.viewstate.strategy.alias.AddToEndSingle
+import moxy.viewstate.strategy.alias.AddToEndSingleTag
 import moxy.viewstate.strategy.alias.OneExecution
 
 /**
@@ -32,19 +33,19 @@ interface DailyPictureView : MvpView {
      * different picture is loaded, and it should still be displayed
      * after screen rotation.
      */
-    @StateStrategyType(value = AddToEndSingleTagStrategy::class, tag = "show_hide_image")
+    @AddToEndSingleTag(tag = "show_hide_image")
     fun showImage(url: String)
 
-    @StateStrategyType(value = AddToEndSingleTagStrategy::class, tag = "show_hide_image")
+    @AddToEndSingleTag(tag = "show_hide_image")
     fun showVideo()
 
-    @StateStrategyType(value = AddToEndSingleTagStrategy::class, tag = "show_hide_image")
+    @AddToEndSingleTag(tag = "show_hide_image")
     fun hideImage()
 
-    @StateStrategyType(value = AddToEndSingleTagStrategy::class, tag = "show_hide_copyright")
+    @AddToEndSingleTag(tag = "show_hide_copyright")
     fun showCopyright(text: String)
 
-    @StateStrategyType(value = AddToEndSingleTagStrategy::class, tag = "show_hide_copyright")
+    @AddToEndSingleTag(tag = "show_hide_copyright")
     fun hideCopyright()
 
     @AddToEndSingle


### PR DESCRIPTION
Now Moxy allows to specify tags in state strategy aliases.
Example:
```
@StateStrategyType(AddToEndSingleTagStrategy.class)
@interface AddToEndSingleTag {
    @StateStrategyTypeTag
    String tag() default "";
}
```

Also, there's new state strategy alias which supports it: `@AddToEndSingleTag`